### PR TITLE
feat!: remove client access policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ No modules.
 | Name | Type |
 |------|------|
 | [azurerm_key_vault.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault) | resource |
-| [azurerm_key_vault_access_policy.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_monitor_diagnostic_setting.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 
@@ -86,9 +85,6 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_application"></a> [application](#input\_application) | The application to create the resources for. | `string` | n/a | yes |
-| <a name="input_client_certificate_permissions"></a> [client\_certificate\_permissions](#input\_client\_certificate\_permissions) | A list of Key Vault Certificate permissions to assign to the current client. | `list(string)` | `[]` | no |
-| <a name="input_client_key_permissions"></a> [client\_key\_permissions](#input\_client\_key\_permissions) | A list of Key Vault Key permissions to assign to the current client. | `list(string)` | `[]` | no |
-| <a name="input_client_secret_permissions"></a> [client\_secret\_permissions](#input\_client\_secret\_permissions) | A list of Key Vault Secret permissions to assign to the current client. | `list(string)` | <pre>[<br>  "Get",<br>  "List",<br>  "Set",<br>  "Delete",<br>  "Recover",<br>  "Backup",<br>  "Restore"<br>]</pre> | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment to create the resources for. | `string` | n/a | yes |
 | <a name="input_firewall_ip_rules"></a> [firewall\_ip\_rules](#input\_firewall\_ip\_rules) | A list of IP addresses or CIDR blocks that should be able to access the Key Vault. | `list(string)` | `[]` | no |
 | <a name="input_firewall_subnet_rules"></a> [firewall\_subnet\_rules](#input\_firewall\_subnet\_rules) | A list of IDs of the subnets that should be able to access the Key Vault. | `list(string)` | `[]` | no |

--- a/main.tf
+++ b/main.tf
@@ -30,17 +30,6 @@ resource "azurerm_key_vault" "this" {
   }
 }
 
-resource "azurerm_key_vault_access_policy" "this" {
-  key_vault_id = azurerm_key_vault.this.id
-  tenant_id    = data.azurerm_client_config.current.tenant_id
-  object_id    = data.azurerm_client_config.current.object_id
-
-  secret_permissions      = var.client_secret_permissions
-  certificate_permissions = var.client_certificate_permissions
-  key_permissions         = var.client_key_permissions
-  storage_permissions     = []
-}
-
 resource "azurerm_monitor_diagnostic_setting" "this" {
   name                       = "${azurerm_key_vault.this.name}-logs"
   target_resource_id         = azurerm_key_vault.this.id

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,11 +1,6 @@
 output "key_vault_id" {
   description = "The ID of the Key Vault."
   value       = azurerm_key_vault.this.id
-
-  depends_on = [
-    # Current client must have access to the Key Vault before managing its contents.
-    azurerm_key_vault_access_policy.this
-  ]
 }
 
 output "key_vault_name" {

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -34,17 +34,5 @@ module "vault" {
 
   firewall_ip_rules = var.firewall_ip_rules
 
-  client_secret_permissions = ["Get", "List", "Set", "Delete", "Recover", "Backup", "Restore", "Purge"]
-
   log_analytics_workspace_id = azurerm_log_analytics_workspace.this.id
-}
-
-resource "random_password" "this" {
-  length = 16
-}
-
-resource "azurerm_key_vault_secret" "this" {
-  name         = "password"
-  value        = random_password.this.result
-  key_vault_id = module.vault.key_vault_id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -48,24 +48,6 @@ variable "firewall_subnet_rules" {
   default     = []
 }
 
-variable "client_secret_permissions" {
-  description = "A list of Key Vault Secret permissions to assign to the current client."
-  type        = list(string)
-  default     = ["Get", "List", "Set", "Delete", "Recover", "Backup", "Restore"]
-}
-
-variable "client_certificate_permissions" {
-  description = "A list of Key Vault Certificate permissions to assign to the current client."
-  type        = list(string)
-  default     = []
-}
-
-variable "client_key_permissions" {
-  description = "A list of Key Vault Key permissions to assign to the current client."
-  type        = list(string)
-  default     = []
-}
-
 variable "log_analytics_workspace_id" {
   description = "The ID of the Log Analytics Workspace to send diagnostics to."
   type        = string


### PR DESCRIPTION
Remove default key vault access policy for current client to improve the security of the key vault created by this module. If current client needs access to key vault, create a key vault access policy resource for this key vault outside of this module.

BREAKING CHANGE: variable `azurerm_key_vault_access_policy.this` removed

BREAKING CHANGE: variable `client_secret_permissions` removed

BREAKING CHANGE: variable `client_certificate_permissions` removed

BREAKING CHANGE: variable `client_key_permissions` has been removed

Closes #18
