### PR TITLE
refactor!: update variables and outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,23 +86,19 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_access_policies"></a> [access\_policies](#input\_access\_policies) | A list of access policies for this Key Vault. | <pre>list(object({<br>    object_id               = string<br>    secret_permissions      = list(string)<br>    certificate_permissions = list(string)<br>    key_permissions         = list(string)<br>  }))</pre> | `[]` | no |
-| <a name="input_application"></a> [application](#input\_application) | The application to create the resources for. | `string` | n/a | yes |
-| <a name="input_environment"></a> [environment](#input\_environment) | The environment to create the resources for. | `string` | n/a | yes |
 | <a name="input_firewall_ip_rules"></a> [firewall\_ip\_rules](#input\_firewall\_ip\_rules) | A list of IP addresses or CIDR blocks that should be able to access the Key Vault. | `list(string)` | `[]` | no |
 | <a name="input_firewall_subnet_rules"></a> [firewall\_subnet\_rules](#input\_firewall\_subnet\_rules) | A list of IDs of the subnets that should be able to access the Key Vault. | `list(string)` | `[]` | no |
-| <a name="input_key_vault_name"></a> [key\_vault\_name](#input\_key\_vault\_name) | A custom name for the Key Vault. | `string` | `null` | no |
 | <a name="input_location"></a> [location](#input\_location) | The supported Azure location where the resources exist. | `string` | n/a | yes |
 | <a name="input_log_analytics_workspace_id"></a> [log\_analytics\_workspace\_id](#input\_log\_analytics\_workspace\_id) | The ID of the Log Analytics Workspace to send diagnostics to. | `string` | n/a | yes |
 | <a name="input_purge_protection_enabled"></a> [purge\_protection\_enabled](#input\_purge\_protection\_enabled) | Is purge protection enabled for this key vault? | `bool` | `false` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group in which to create the resources. | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the resources. | `map(string)` | `{}` | no |
+| <a name="input_vault_name"></a> [vault\_name](#input\_vault\_name) | The name of this Key Vault. | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_key_vault_id"></a> [key\_vault\_id](#output\_key\_vault\_id) | The ID of the Key Vault. |
-| <a name="output_key_vault_name"></a> [key\_vault\_name](#output\_key\_vault\_name) | The name of the Key Vault. |
-| <a name="output_key_vault_uri"></a> [key\_vault\_uri](#output\_key\_vault\_uri) | The URI of the Key Vault. |
-| <a name="output_monitor_diagnostic_setting_id"></a> [monitor\_diagnostic\_setting\_id](#output\_monitor\_diagnostic\_setting\_id) | The ID of the Monitor Diagnostic Setting. |
+| <a name="output_vault_id"></a> [vault\_id](#output\_vault\_id) | The ID of the Key Vault. |
+| <a name="output_vault_uri"></a> [vault\_uri](#output\_vault\_uri) | The URI of the Key Vault. |
 <!-- END_TF_DOCS -->

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,7 @@
-locals {
-  tags = merge({ application = var.application, environment = var.environment }, var.tags)
-}
-
 data "azurerm_client_config" "current" {}
 
 resource "azurerm_key_vault" "this" {
-  name                = coalesce(var.key_vault_name, "kv-${var.application}-${var.environment}")
+  name                = var.vault_name
   location            = var.location
   resource_group_name = var.resource_group_name
   sku_name            = "standard"
@@ -22,7 +18,7 @@ resource "azurerm_key_vault" "this" {
   access_policy             = null
   enable_rbac_authorization = false
 
-  tags = local.tags
+  tags = var.tags
 
   network_acls {
     bypass                     = "AzureServices"

--- a/outputs.tf
+++ b/outputs.tf
@@ -12,8 +12,3 @@ output "vault_uri" {
   description = "The URI of the Key Vault."
   value       = azurerm_key_vault.this.vault_uri
 }
-
-output "monitor_diagnostic_setting_id" {
-  description = "The ID of the Monitor Diagnostic Setting."
-  value       = azurerm_monitor_diagnostic_setting.this.id
-}

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,11 +8,6 @@ output "vault_id" {
   ]
 }
 
-output "vault_name" {
-  description = "The name of the Key Vault."
-  value       = azurerm_key_vault.this.name
-}
-
 output "vault_uri" {
   description = "The URI of the Key Vault."
   value       = azurerm_key_vault.this.vault_uri

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
-output "key_vault_id" {
+output "vault_id" {
   description = "The ID of the Key Vault."
   value       = azurerm_key_vault.this.id
 
@@ -8,12 +8,12 @@ output "key_vault_id" {
   ]
 }
 
-output "key_vault_name" {
+output "vault_name" {
   description = "The name of the Key Vault."
   value       = azurerm_key_vault.this.name
 }
 
-output "key_vault_uri" {
+output "vault_uri" {
   description = "The URI of the Key Vault."
   value       = azurerm_key_vault.this.vault_uri
 }

--- a/test/fixture/outputs.tf
+++ b/test/fixture/outputs.tf
@@ -1,3 +1,1 @@
-output "key_vault_uri" {
-  value = module.vault.key_vault_uri
-}
+

--- a/test/fixture/variables.tf
+++ b/test/fixture/variables.tf
@@ -2,8 +2,3 @@ variable "location" {
   type    = string
   default = "northeurope"
 }
-
-variable "firewall_ip_rules" {
-  type    = list(string)
-  default = []
-}

--- a/test/terraform_vault_test.go
+++ b/test/terraform_vault_test.go
@@ -1,43 +1,14 @@
 package test
 
 import (
-	"io"
-	"net/http"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 )
 
-const TerraformDir = "./fixture"
-
 func TestTerraformVault(t *testing.T) {
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
-		TerraformDir: TerraformDir,
-	})
-
-	defer terraform.Destroy(t, terraformOptions)
-
-	terraform.InitAndApply(t, terraformOptions)
-}
-
-func TestTerraformVaultFirewall(t *testing.T) {
-	// Get public IP address
-	resp, err := http.Get("https://ifconfig.me/")
-	if err != nil {
-		panic(err)
-	}
-	defer resp.Body.Close()
-	ip, err := io.ReadAll(resp.Body)
-	if err != nil {
-		panic(err)
-	}
-
-	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
-		TerraformDir: TerraformDir,
-
-		Vars: map[string]interface{}{
-			"firewall_ip_rules": []string{string(ip)},
-		},
+		TerraformDir: "./fixture",
 	})
 
 	defer terraform.Destroy(t, terraformOptions)

--- a/variables.tf
+++ b/variables.tf
@@ -1,17 +1,6 @@
-variable "application" {
-  description = "The application to create the resources for."
+variable "vault_name" {
+  description = "The name of this Key Vault."
   type        = string
-}
-
-variable "environment" {
-  description = "The environment to create the resources for."
-  type        = string
-}
-
-variable "key_vault_name" {
-  description = "A custom name for the Key Vault."
-  type        = string
-  default     = null
 }
 
 variable "location" {


### PR DESCRIPTION
Remove variables "application" and "environment", which are used for setting default names and tags. We usually end up setting custom names and tags anyway, making these variables redundant in most cases.

Use this opportunity to also rename variables to follow a similar naming convention to Microsoft's own tools, e.g. Azure CLI. We use a similar naming convention for our other latest Terraform modules as well.

BREAKING CHANGE: variable `application` removed

BREAKING CHANGE: variable `environment` removed

BREAKING CHANGE: variable `key_vault_name` renamed to `vault_name`

BREAKING CHANGE: variable `vault_name` default value removed

BREAKING CHANGE: output `key_vault_name` removed

BREAKING CHANGE: output `key_vault_id` renamed to `vault_id`

BREAKING CHANGE: output `key_vault_uri` renamed to `vault_uri`

BREAKING CHANGE: output `monitor_diagnostic_setting_id` removed