### PR TITLE
feat!: create access policies using `access_policy` argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ No modules.
 | Name | Type |
 |------|------|
 | [azurerm_key_vault.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault) | resource |
-| [azurerm_key_vault_access_policy.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_monitor_diagnostic_setting.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -22,7 +22,7 @@ resource "azurerm_resource_group" "this" {
 }
 
 module "log_analytics" {
-  source = "github.com/equinor/terraform-azurerm-log-analytics?ref=v1.0.0"
+  source = "github.com/equinor/terraform-azurerm-log-analytics?ref=v1.1.0"
 
   workspace_name      = "log-${random_id.this.hex}"
   resource_group_name = azurerm_resource_group.this.name

--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,7 @@ locals {
   access_policies = [
     for p in var.access_policies : {
       tenant_id               = data.azurerm_client_config.current.tenant_id
+      application_id          = ""
       object_id               = p.object_id
       secret_permissions      = p.secret_permissions
       certificate_permissions = p.certificate_permissions

--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,6 @@ resource "azurerm_key_vault" "this" {
   enabled_for_disk_encryption     = false
   enabled_for_template_deployment = false
 
-  # Access policies must be created using the `azurerm_key_vault_access_policy` resource, to prevent conflicts.
   access_policy             = local.access_policies
   enable_rbac_authorization = false
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,11 +1,6 @@
 output "vault_id" {
   description = "The ID of this Key vault."
   value       = azurerm_key_vault.this.id
-
-  depends_on = [
-    # Access policies should be created before managing Key Vault objects.
-    azurerm_key_vault_access_policy.this
-  ]
 }
 
 output "vault_name" {


### PR DESCRIPTION
BREAKING CHANGE: define access policies within the `azurerm_key_vault.this` resources via the `access_policy` argument instead of using the `azurerm_key_vault_access_policy.this` resource. Remove the `azurerm_key_vault_access_policy.this` resource(s) from your state file using `terraform state rm` before upgrading to migrate your project.

Closes #26 