### PR TITLE
refactor!: rename variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_access_policies"></a> [access\_policies](#input\_access\_policies) | A list of access policies for this Key vault. | <pre>list(object({<br>    object_id               = string<br>    secret_permissions      = optional(list(string), [])<br>    certificate_permissions = optional(list(string), [])<br>    key_permissions         = optional(list(string), [])<br>  }))</pre> | `[]` | no |
-| <a name="input_firewall_bypass_azure"></a> [firewall\_bypass\_azure](#input\_firewall\_bypass\_azure) | Should Azure services be able to bypass the Key vault firewall? | `bool` | `true` | no |
-| <a name="input_firewall_ip_rules"></a> [firewall\_ip\_rules](#input\_firewall\_ip\_rules) | A list of IP addresses or CIDR blocks that should be able to access this Key vault. | `list(string)` | `[]` | no |
-| <a name="input_firewall_subnet_rules"></a> [firewall\_subnet\_rules](#input\_firewall\_subnet\_rules) | A list of IDs of the subnets that should be able to access this Key vault. | `list(string)` | `[]` | no |
 | <a name="input_location"></a> [location](#input\_location) | The location to create the resources in. | `string` | n/a | yes |
 | <a name="input_log_analytics_workspace_id"></a> [log\_analytics\_workspace\_id](#input\_log\_analytics\_workspace\_id) | The ID of the Log Analytics workspace to send diagnostics to. | `string` | n/a | yes |
+| <a name="input_network_acls_bypass_azure_services"></a> [network\_acls\_bypass\_azure\_services](#input\_network\_acls\_bypass\_azure\_services) | Should Azure services be able to bypass the network ACL and access this Key vault? | `bool` | `true` | no |
+| <a name="input_network_acls_ip_rules"></a> [network\_acls\_ip\_rules](#input\_network\_acls\_ip\_rules) | A list of IP addresses or CIDR blocks that should be able to bypass the network ACL and access this Key vault. | `list(string)` | `[]` | no |
+| <a name="input_network_acls_virtual_network_subnet_ids"></a> [network\_acls\_virtual\_network\_subnet\_ids](#input\_network\_acls\_virtual\_network\_subnet\_ids) | A list of Virtual Network subnet IDs that should be able to bypass the network ACL and access this Key vault. | `list(string)` | `[]` | no |
 | <a name="input_purge_protection_enabled"></a> [purge\_protection\_enabled](#input\_purge\_protection\_enabled) | Is purge protection enabled for this Key vault? | `bool` | `false` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group to create the resources in. | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to the resources. | `map(string)` | `{}` | no |
@@ -48,6 +48,6 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_vault_id"></a> [vault\_id](#output\_vault\_id) | The ID of this Key vault. |
-| <a name="output_vault_name"></a> [vault\_name](#output\_vault\_name) | The name of this Key Vault. |
+| <a name="output_vault_name"></a> [vault\_name](#output\_vault\_name) | The name of this Key vault. |
 | <a name="output_vault_uri"></a> [vault\_uri](#output\_vault\_uri) | The URI of this Key vault. |
 <!-- END_TF_DOCS -->

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -47,11 +47,5 @@ module "key_vault" {
     }
   ]
 
-  firewall_ip_rules = [
-    "1.1.1.1/32",
-    "2.2.2.2/32",
-    "3.3.3.3/32"
-  ]
-
   tags = local.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ locals {
     }
   ]
 
-  firewall_bypass = var.firewall_bypass_azure ? "AzureServices" : "None"
+  network_acls_bypass = var.network_acls_bypass_azure_services ? "AzureServices" : "None"
 }
 
 data "azurerm_client_config" "current" {}
@@ -36,10 +36,10 @@ resource "azurerm_key_vault" "this" {
   tags = var.tags
 
   network_acls {
-    bypass                     = local.firewall_bypass
-    default_action             = length(var.firewall_ip_rules) == 0 && length(var.firewall_subnet_rules) == 0 && local.firewall_bypass == "None" ? "Allow" : "Deny"
-    ip_rules                   = var.firewall_ip_rules
-    virtual_network_subnet_ids = var.firewall_subnet_rules
+    bypass                     = local.network_acls_bypass
+    default_action             = length(var.network_acls_ip_rules) == 0 && length(var.network_acls_virtual_network_subnet_ids) == 0 && local.network_acls_bypass == "None" ? "Allow" : "Deny"
+    ip_rules                   = var.network_acls_ip_rules
+    virtual_network_subnet_ids = var.network_acls_virtual_network_subnet_ids
   }
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,7 +4,7 @@ output "vault_id" {
 }
 
 output "vault_name" {
-  description = "The name of this Key Vault."
+  description = "The name of this Key vault."
   value       = azurerm_key_vault.this.name
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -31,19 +31,19 @@ variable "access_policies" {
 }
 
 variable "network_acls_ip_rules" {
-  description = "A list of IP addresses or CIDR blocks that should be able to access this Key vault."
+  description = "A list of IP addresses or CIDR blocks that should be able to bypass the network ACL and access this Key vault."
   type        = list(string)
   default     = []
 }
 
 variable "network_acls_virtual_network_subnet_ids" {
-  description = "A list of IDs of the subnets that should be able to access this Key vault."
+  description = "A list of Virtual Network subnet IDs that should be able to bypass the network ACL and access this Key vault."
   type        = list(string)
   default     = []
 }
 
 variable "network_acls_bypass_azure_services" {
-  description = "Should Azure services be able to bypass the Key vault firewall?"
+  description = "Should Azure services be able to bypass the network ACL and access this Key vault?"
   type        = bool
   default     = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -30,19 +30,19 @@ variable "access_policies" {
   default = []
 }
 
-variable "firewall_ip_rules" {
+variable "network_acls_ip_rules" {
   description = "A list of IP addresses or CIDR blocks that should be able to access this Key vault."
   type        = list(string)
   default     = []
 }
 
-variable "firewall_subnet_rules" {
+variable "network_acls_virtual_network_subnet_ids" {
   description = "A list of IDs of the subnets that should be able to access this Key vault."
   type        = list(string)
   default     = []
 }
 
-variable "firewall_bypass_azure" {
+variable "network_acls_bypass_azure_services" {
   description = "Should Azure services be able to bypass the Key vault firewall?"
   type        = bool
   default     = true


### PR DESCRIPTION
Rename variables to follow internal best practices.

BREAKING CHANGE: rename variable `firewall_ip_rules` to `network_acls_ip_rules`

BREAKING CHANGE: rename variable `firewall_subnet_rules` to `network_acls_virtual_network_subnet_ids`

BREAKING CHANGE: rename variable `firewall_bypass_azure` to `network_acls_bypass_azure_services`