### PR TITLE
feat: set diagnostic setting enabled log categories

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -22,7 +22,7 @@ resource "azurerm_resource_group" "this" {
 }
 
 module "log_analytics" {
-  source = "github.com/equinor/terraform-azurerm-log-analytics?ref=v1.3.0"
+  source = "github.com/equinor/terraform-azurerm-log-analytics?ref=v1.5.0"
 
   workspace_name      = "log-${random_id.this.hex}"
   resource_group_name = azurerm_resource_group.this.name

--- a/main.tf
+++ b/main.tf
@@ -47,12 +47,11 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
   log_analytics_workspace_id     = var.log_analytics_workspace_id
   log_analytics_destination_type = var.log_analytics_destination_type
 
-  enabled_log {
-    category = "AuditEvent"
+  dynamic "enabled_log" {
+    for_each = toset(var.diagnostic_setting_enabled_log_categories)
 
-    retention_policy {
-      days    = 0
-      enabled = false
+    content {
+      category = enabled_log.value
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -72,6 +72,12 @@ variable "diagnostic_setting_name" {
   default     = "audit-logs"
 }
 
+variable "diagnostic_setting_enabled_log_categories" {
+  description = "A list of log categories to be enabled for this diagnostic setting."
+  type        = list(string)
+  default     = ["AuditEvent"]
+}
+
 variable "log_analytics_workspace_id" {
   description = "The ID of the Log Analytics workspace to send diagnostics to."
   type        = string


### PR DESCRIPTION
added diagnostic setting to enable log categories in KeyVault.

Included AuditEvents as the only category since it is the only one that has no cost to export

Ref.

https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/resource-logs-categories#microsoftkeyvaultvaults
