### PR TITLE
feat: enable public network access

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -31,7 +31,7 @@ resource "azurerm_key_vault" "this" {
   access_policy             = local.access_policies
   enable_rbac_authorization = var.enable_rbac_authorization
 
-  tags = var.tags
+  public_network_access_enabled = var.public_network_access_enabled
 
   network_acls {
     default_action             = "Deny"
@@ -39,6 +39,8 @@ resource "azurerm_key_vault" "this" {
     ip_rules                   = var.network_acls_ip_rules
     virtual_network_subnet_ids = var.network_acls_virtual_network_subnet_ids
   }
+
+  tags = var.tags
 }
 
 resource "azurerm_monitor_diagnostic_setting" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -42,6 +42,12 @@ variable "enable_rbac_authorization" {
   default     = true
 }
 
+variable "public_network_access_enabled" {
+  description = "Should public network access be enabled for this Key Vault?"
+  type        = bool
+  default     = true
+}
+
 variable "network_acls_bypass_azure_services" {
   description = "Should Azure services be allowed to bypass the network ACLs of this Key Vault?."
   type        = bool


### PR DESCRIPTION
Allow disabling public network access completely.

Default value of added variable set to `true`, which is the default value of argument `public_network_access_enabled` for resource `azurerm_key_vault`.