### PR TITLE
chore: update basic example

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -1,5 +1,9 @@
 provider "azurerm" {
-  features {}
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy = false
+    }
+  }
 }
 
 resource "random_id" "this" {


### PR DESCRIPTION
Update basic example to not purge key vault on destroy, as that would require permissions at the subscription scope.