### PR TITLE
wip: create object neary expiry alerts

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -72,3 +72,55 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
     }
   }
 }
+
+# Ref: https://learn.microsoft.com/en-us/azure/key-vault/general/alert#example-log-query-alert-for-near-expiry-certificates (2024-08-27)
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "secret_near_expiry" {
+  name                = "Secret near expiry - ${azurerm_key_vault.this.name}"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  scopes              = [azurerm_key_vault.this.id]
+  description         = "" # TODO
+
+  criteria {
+    query = <<-QUERY
+    AzureDiagnostics
+      | where OperationName == 'SecretNearExpiryEventGridNotification'
+      | extend SecretExpire = unixtime_seconds_todatetime(eventGridEventProperties_data_EXP_d)
+      | extend DaysTillExpire = datetime_diff("Day", SecretExpire, now())
+      | project ResourceId, SecretName = eventGridEventProperties_subject_s, DaysTillExpire, SecretExpire
+    QUERY
+
+    time_aggregation_method = "Count" # TODO: aggregation granularity?
+    resource_id_column      = "ResourceId"
+    operator                = "GreaterThan"
+    threshold               = 0
+
+    # Ensure unique SecretName + DaysTillExpire combinations will trigger separate alerts
+    dimension {
+      name     = "SecretName"
+      operator = "Include"
+      values   = ["*"]
+    }
+    dimension {
+      name     = "DaysTillExpire"
+      operator = "Include"
+      values   = ["*"]
+    }
+  }
+
+  # Configure alert to run once per day, and evaluate logs from the entire previous day
+  evaluation_frequency = "P1D" # TODO
+  window_duration      = "P1D" # TODO
+
+  severity = 2 # Warning
+
+  # Sometimes fails during creation since no logs exist yet.
+  # Skip that validation.
+  skip_query_validation = true
+
+  action {
+    action_groups = [] # TODO
+  }
+
+  tags = var.tags
+}


### PR DESCRIPTION
Currently fails during creation of `azurerm_monitor_scheduled_query_rules_alert_v2.secret_near_expiry` resource:

```plaintext
module.key_vault.azurerm_monitor_scheduled_query_rules_alert_v2.secret_near_expiry: Creating...
╷
│ Error: creating Scheduled Query Rule (Subscription: "<SUBSCRIPTION_ID>"
│ Resource Group Name: "<RESOURCE_GROUP_NAME>"
│ Scheduled Query Rule Name: "Secret near expiry - kv-51986fdc6839ac13"): unexpected status 400 (400 Bad Request) with error: BadRequest: 'project' operator: Failed to resolve scalar expression named 'ResultDescription_ssic' Activity ID: de9e567f-63ad-4f4d-b85e-bdfc6dbc625c.
│
│   with module.key_vault.azurerm_monitor_scheduled_query_rules_alert_v2.secret_near_expiry,
│   on ..\..\main.tf line 77, in resource "azurerm_monitor_scheduled_query_rules_alert_v2" "secret_near_expiry":
│   77: resource "azurerm_monitor_scheduled_query_rules_alert_v2" "secret_near_expiry" {
╵
```

My theory is that the newly created Key Vault doesn't have any logs yet, thus the query fails.