### PR TITLE
fix: argument `metric` for resource `azurerm_monitor_diagnostic_setting` has been deprecated

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,8 +10,6 @@ locals {
       storage_permissions     = []
     }
   ]
-
-  diagnostic_setting_metric_categories = ["AllMetrics"]
 }
 
 data "azurerm_client_config" "current" {}
@@ -67,13 +65,11 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
     }
   }
 
-  dynamic "metric" {
-    for_each = toset(concat(local.diagnostic_setting_metric_categories, var.diagnostic_setting_enabled_metric_categories))
+  dynamic "enabled_metric" {
+    for_each = toset(var.diagnostic_setting_enabled_metric_categories)
 
     content {
-      # Azure expects explicit configuration of both enabled and disabled metric categories.
-      category = metric.value
-      enabled  = contains(var.diagnostic_setting_enabled_metric_categories, metric.value)
+      category = enabled_metric.value
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -3,8 +3,9 @@ terraform {
 
   required_providers {
     azurerm = {
-      source  = "hashicorp/azurerm"
-      version = ">= 3.39.0"
+      source = "hashicorp/azurerm"
+      # Version 4.31.0 is required to use the "enabled_metric" argument for the "azurerm_monitor_diagnostic_setting" resource.
+      version = ">= 4.31.0"
     }
   }
 }


### PR DESCRIPTION
- Replace argument `metric` with `enabled_metric`.
- Bump minimum allowed Azure provider version. Version 4.31.0 is required to use the `enabled_metric` argument.