### PR TITLE
feat: configure Microsoft Entra tenant ID

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ resource "azurerm_key_vault" "this" {
   location            = var.location
   resource_group_name = var.resource_group_name
   sku_name            = "standard"
-  tenant_id           = data.azurerm_client_config.current.tenant_id
+  tenant_id           = coalesce(var.tenant_id, data.azurerm_client_config.current.tenant_id)
 
   soft_delete_retention_days = var.soft_delete_retention_days
   purge_protection_enabled   = var.purge_protection_enabled

--- a/tests/setup/main.tf
+++ b/tests/setup/main.tf
@@ -13,6 +13,8 @@ resource "random_id" "name_suffix" {
 
 resource "random_uuid" "subscription_id" {}
 
+resource "random_uuid" "tenant_id" {}
+
 locals {
   name_suffix         = random_id.name_suffix.hex
   resource_group_name = "rg-${local.name_suffix}"

--- a/tests/setup/outputs.tf
+++ b/tests/setup/outputs.tf
@@ -13,3 +13,7 @@ output "location" {
 output "log_analytics_workspace_id" {
   value = "/subscriptions/${random_uuid.subscription_id.result}/resourceGroups/${local.resource_group_name}/providers/Microsoft.OperationalInsights/workspaces/log-${local.name_suffix}"
 }
+
+output "tenant_id" {
+  value = random_uuid.tenant_id.result
+}

--- a/tests/soft-delete.tftest.hcl
+++ b/tests/soft-delete.tftest.hcl
@@ -1,12 +1,5 @@
 mock_provider "azurerm" {}
 
-override_data {
-  target = data.azurerm_client_config.current
-  values = {
-    tenant_id = "90bf3c67-d9ec-4fb2-ade0-1141d5dd5bbf" # Randomly generated
-  }
-}
-
 run "setup_tests" {
   module {
     source = "./tests/setup"
@@ -21,6 +14,7 @@ run "soft_delete_defaults" {
     resource_group_name        = run.setup_tests.resource_group_name
     location                   = run.setup_tests.location
     log_analytics_workspace_id = run.setup_tests.log_analytics_workspace_id
+    tenant_id                  = run.setup_tests.tenant_id
   }
 
   assert {
@@ -42,6 +36,7 @@ run "soft_delete_retention" {
     resource_group_name        = run.setup_tests.resource_group_name
     location                   = run.setup_tests.location
     log_analytics_workspace_id = run.setup_tests.log_analytics_workspace_id
+    tenant_id                  = run.setup_tests.tenant_id
 
     soft_delete_retention_days = 7
   }
@@ -60,6 +55,7 @@ run "purge_protection_enabled" {
     resource_group_name        = run.setup_tests.resource_group_name
     location                   = run.setup_tests.location
     log_analytics_workspace_id = run.setup_tests.log_analytics_workspace_id
+    tenant_id                  = run.setup_tests.tenant_id
 
     purge_protection_enabled = true
   }
@@ -78,6 +74,7 @@ run "purge_protection_disabled" {
     resource_group_name        = run.setup_tests.resource_group_name
     location                   = run.setup_tests.location
     log_analytics_workspace_id = run.setup_tests.log_analytics_workspace_id
+    tenant_id                  = run.setup_tests.tenant_id
 
     purge_protection_enabled = false
   }

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,13 @@ variable "location" {
   type        = string
 }
 
+variable "tenant_id" {
+  description = "The ID of the Microsoft Entra tenant that should be used for authenticating requests to this Key Vault. If value is set to null, the ID of the current tenant will be used."
+  type        = string
+  nullable    = true
+  default     = null
+}
+
 variable "soft_delete_retention_days" {
   description = "The number of days that items should be retained for once soft-deleted."
   type        = number


### PR DESCRIPTION
Allow configuration of Microsoft Entra tenant ID that should be used for authenticating requests to this Key Vault.

Useful for passing a randomly generated tenant ID to a mock provider when writing tests for this module.